### PR TITLE
Exclude node_modules

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,10 @@
 {
   "extends": "tslint-config-airbnb",
+  "linterOptions": {
+      "exclude": [
+          "node_modules/**"
+      ]
+  },
   "rules": {
     "max-line-length": [ true, 160 ],
     "no-console": false


### PR DESCRIPTION
Since we have no control over the style of the dependencies we should not check it